### PR TITLE
fix: avoid never types

### DIFF
--- a/update.d.ts
+++ b/update.d.ts
@@ -9,29 +9,16 @@ export namespace Update {
   /** Internal type holding properties that message updates in channels share. */
   export interface Channel {
     chat: Chat.ChannelChat;
-    author_signature?: string;
-    from?: never;
   }
   /** Internal type holding properties that message updates outside of channels share. */
   export interface NonChannel {
     chat: Exclude<Chat, Chat.ChannelChat>;
-    author_signature?: never;
     from: User;
-  }
-  /** Internal type holding properties that updates about new messages share. */
-  export interface New {
-    edit_date?: never;
   }
   /** Internal type holding properties that updates about edited messages share. */
   export interface Edited {
     /** Date the message was last edited in Unix time */
     edit_date: number;
-    forward_from?: never;
-    forward_from_chat?: never;
-    forward_from_message_id?: never;
-    forward_signature?: never;
-    forward_sender_name?: never;
-    forward_date?: never;
   }
 }
 
@@ -41,11 +28,11 @@ export interface Update {
   /** The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you're using webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially. */
   update_id: number;
   /** New incoming message of any kind - text, photo, sticker, etc. */
-  message?: Message & Update.New & Update.NonChannel;
+  message?: Message & Update.NonChannel;
   /** New version of a message that is known to the bot and was edited */
   edited_message?: Message & Update.Edited & Update.NonChannel;
   /** New incoming channel post of any kind - text, photo, sticker, etc. */
-  channel_post?: Message & Update.New & Update.Channel;
+  channel_post?: Message & Update.Channel;
   /** New version of a channel post that is known to the bot and was edited */
   edited_channel_post?: Message & Update.Edited & Update.Channel;
   /** New incoming inline query */


### PR DESCRIPTION
We only guarantee properties that are known to be present, but never remove properties that are known to be absent. grammyjs/types#15 broke with this philosophy and led to grammyjs/hydrate#11. This PQ fixes that.

Towards grammyjs/hydrate#11.