### PR TITLE
Work around for Vite to recognize an empty file as a valid module

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,6 @@
+/* The comment below makes Vite recognize an empty main file as a valid CJS module. */
+// module.exports
+
 export * from "./api.ts";
 export * from "./inline.ts";
 export * from "./manage.ts";


### PR DESCRIPTION
Fixes #23 