### PR TITLE
fix: suppress vite warning

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1,0 +1,2 @@
+/* The comment below makes Vite recognize an empty main file as a valid CJS module. */
+// module.exports

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,3 @@
-/* The comment below makes Vite recognize an empty main file as a valid CJS module. */
-// module.exports
-
 export * from "./api.ts";
 export * from "./inline.ts";
 export * from "./manage.ts";


### PR DESCRIPTION
`emitDeclarationOnly` prevents TS from outputting JS files. The comment was added to `mod.ts` but should have been added to `mod.js` as it otherwise is not shipped to npm.

Fixes #23.