### PR TITLE
Fixed typing of WebhookInfo

### DIFF
--- a/manage.ts
+++ b/manage.ts
@@ -9,18 +9,18 @@ export interface WebhookInfo {
   has_custom_certificate: boolean;
   /** Number of updates awaiting delivery */
   pending_update_count: number;
-  /** Currently used webhook IP address */
+  /** Optional. Currently used webhook IP address */
   ip_address?: string;
-  /** Unix time for the most recent error that happened when trying to deliver an update via webhook */
-  last_error_date: number;
-  /** Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook */
-  last_error_message: string;
-  /** Unix time of the most recent error that happened when trying to synchronize available updates with Telegram datacenters */
+  /** Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook */
+  last_error_date?: number;
+  /** Optional. Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook */
+  last_error_message?: string;
+  /** Optional. Unix time of the most recent error that happened when trying to synchronize available updates with Telegram datacenters */
   last_synchronization_error_date?: number;
-  /** The maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery */
-  max_connections: number;
-  /** A list of update types the bot is subscribed to. Defaults to all update types except chat_member */
-  allowed_updates: Array<Exclude<keyof Update, "update_id">>;
+  /** Optional. The maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery */
+  max_connections?: number;
+  /** Optional. A list of update types the bot is subscribed to. Defaults to all update types except chat_member */
+  allowed_updates?: Array<Exclude<keyof Update, "update_id">>;
 }
 
 /** This object represents a Telegram user or bot. */

--- a/manage.ts
+++ b/manage.ts
@@ -9,17 +9,17 @@ export interface WebhookInfo {
   has_custom_certificate: boolean;
   /** Number of updates awaiting delivery */
   pending_update_count: number;
-  /** Optional. Currently used webhook IP address */
+  /** Currently used webhook IP address */
   ip_address?: string;
-  /** Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook */
+  /** Unix time for the most recent error that happened when trying to deliver an update via webhook */
   last_error_date?: number;
-  /** Optional. Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook */
+  /** Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook */
   last_error_message?: string;
-  /** Optional. Unix time of the most recent error that happened when trying to synchronize available updates with Telegram datacenters */
+  /** Unix time of the most recent error that happened when trying to synchronize available updates with Telegram datacenters */
   last_synchronization_error_date?: number;
-  /** Optional. The maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery */
+  /** The maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery */
   max_connections?: number;
-  /** Optional. A list of update types the bot is subscribed to. Defaults to all update types except chat_member */
+  /** A list of update types the bot is subscribed to. Defaults to all update types except chat_member */
   allowed_updates?: Array<Exclude<keyof Update, "update_id">>;
 }
 


### PR DESCRIPTION
Some properties are made optional as in [docs](https://core.telegram.org/bots/api#webhookinfo).