### PR TITLE
feat: support Bot API 7.3

### DIFF
--- a/inline.ts
+++ b/inline.ts
@@ -321,7 +321,7 @@ export interface InlineQueryResultLocation {
   title: string;
   /** The radius of uncertainty for the location, measured in meters; 0-1500 */
   horizontal_accuracy?: number;
-  /** Period in seconds for which the location can be updated, should be between 60 and 86400. */
+  /** Period in seconds during which the location can be updated, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely. */
   live_period?: number;
   /** For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified. */
   heading?: number;
@@ -617,7 +617,7 @@ export interface InputLocationMessageContent {
   longitude: number;
   /** The radius of uncertainty for the location, measured in meters; 0-1500 */
   horizontal_accuracy?: number;
-  /** Period in seconds for which the location can be updated, should be between 60 and 86400. */
+  /** Period in seconds during which the location can be updated, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely. */
   live_period?: number;
   /** For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified. */
   heading?: number;

--- a/manage.ts
+++ b/manage.ts
@@ -64,167 +64,73 @@ export interface UserFromGetMe extends User {
 }
 
 export declare namespace Chat {
-  // ABSTRACT
-  /** Internal type holding properties that all kinds of chats share. */
-  interface AbstractChat {
+  /** Internal type for private chats */
+  export interface PrivateChat {
     /** Unique identifier for this chat. */
     id: number;
-    /** Type of chat, can be either “private”, “group”, “supergroup” or “channel” */
-    type: string;
-  }
-
-  // HELPERS
-  /** Internal type holding properties that those chats with user names share. */
-  interface UserNameChat {
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
+    type: "private";
+    /** Title, for supergroups, channels and group chats */
+    title?: undefined;
     /** Username, for private chats, supergroups and channels if available */
     username?: string;
-  }
-  /** Internal type holding properties that those chats with titles share. */
-  interface TitleChat {
-    /** Title, for supergroups, channels and group chats */
-    title: string;
-  }
-
-  // ==> CHATS
-  /** Internal type representing private chats. */
-  export interface PrivateChat extends AbstractChat, UserNameChat {
-    type: "private";
     /** First name of the other party in a private chat */
     first_name: string;
     /** Last name of the other party in a private chat */
     last_name?: string;
+    /** True, if the supergroup chat is a forum (has topics enabled) */
+    is_forum?: undefined;
   }
-  /** Internal type representing group chats. */
-  export interface GroupChat extends AbstractChat, TitleChat {
+  /** Internal type for group chats */
+  export interface GroupChat {
+    /** Unique identifier for this chat. */
+    id: number;
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
     type: "group";
+    /** Title, for supergroups, channels and group chats */
+    title: string;
+    /** Username, for private chats, supergroups and channels if available */
+    username?: undefined;
+    /** First name of the other party in a private chat */
+    first_name?: undefined;
+    /** Last name of the other party in a private chat */
+    last_name?: undefined;
+    /** True, if the supergroup chat is a forum (has topics enabled) */
+    is_forum?: undefined;
   }
-  /** Internal type representing super group chats. */
-  export interface SupergroupChat
-    extends AbstractChat, UserNameChat, TitleChat {
+  /** Internal type for supergroup chats */
+  export interface SupergroupChat {
+    /** Unique identifier for this chat. */
+    id: number;
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
     type: "supergroup";
+    /** Title, for supergroups, channels and group chats */
+    title: string;
+    /** Username, for private chats, supergroups and channels if available */
+    username?: string;
+    /** First name of the other party in a private chat */
+    first_name?: undefined;
+    /** Last name of the other party in a private chat */
+    last_name?: undefined;
     /** True, if the supergroup chat is a forum (has topics enabled) */
     is_forum?: true;
   }
-  /** Internal type representing channel chats. */
-  export interface ChannelChat extends AbstractChat, UserNameChat, TitleChat {
+  /** Internal type for channel chats */
+  export interface ChannelChat {
+    /** Unique identifier for this chat. */
+    id: number;
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
     type: "channel";
-  }
-
-  // GET CHAT HELPERS
-  /** Internal type holding properties that those chats returned from `getChat` share. */
-  interface GetChat {
-    /** Chat photo. Returned only in getChat. */
-    photo?: ChatPhoto;
-    /** The most recent pinned message (by sending date). Returned only in getChat. */
-    pinned_message?: Message;
-    /** The time after which all messages sent to the chat will be automatically deleted; in seconds. Returned only in getChat. */
-    message_auto_delete_time?: number;
-    /** True, if messages from the chat can't be forwarded to other chats. Returned only in getChat. */
-    has_protected_content?: true;
-  }
-  /** Internal type holding properties that those private, supergroup, and channel chats returned from `getChat` share. */
-  interface NonGroupGetChat {
-    /** If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in getChat. */
-    active_usernames?: string[];
-  }
-  /** Internal type holding properties that those group, supergroup, and channel chats returned from `getChat` share. */
-  interface NonPrivateGetChat {
-    /** Description, for groups, supergroups and channel chats. Returned only in getChat. */
-    description?: string;
-    /** Primary invite link, for groups, supergroups and channel chats. Returned only in getChat. */
-    invite_link?: string;
-    /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. Returned only in getChat. */
-    available_reactions?: ReactionType[];
-  }
-  /** Internal type holding properties that those group and supergroup chats returned from `getChat` share. */
-  interface MultiUserGetChat {
-    /** Default chat member permissions, for groups and supergroups. Returned only in getChat. */
-    permissions?: ChatPermissions;
-  }
-  /** Internal type holding properties that those private and channel chats returned from `getChat` share. */
-  interface NonMultiUserGetChat {
-    /** Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. Returned only in getChat. */
-    accent_color_id: number;
-    /** Custom emoji identifier of emoji chosen by the chat for the reply header and link preview background. Returned only in getChat. */
-    background_custom_emoji_id?: string;
-    /** Custom emoji identifier of the emoji status of the chat or the other party in a private chat. Returned only in getChat. */
-    emoji_status_custom_emoji_id?: string;
-    /** Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any. Returned only in getChat. */
-    emoji_status_expiration_date?: number;
-  }
-  /** Internal type holding properties that those supergroup and channel chats returned from `getChat` share. */
-  interface LargeGetChat {
-    /** Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. Returned only in getChat. */
-    linked_chat_id?: number;
-  }
-
-  // ==> GET CHATS
-  /** Internal type representing private chats returned from `getChat`. */
-  export interface PrivateGetChat
-    extends PrivateChat, GetChat, NonGroupGetChat, NonMultiUserGetChat {
-    /** For private chats, the date of birth of the user. Returned only in getChat. */
-    birthdate?: Birthdate;
-    /** For private chats with business accounts, the intro of the business. Returned only in getChat. */
-    business_intro?: BusinessIntro;
-    /** For private chats with business accounts, the location of the business. Returned only in getChat. */
-    business_location?: BusinessLocation;
-    /** For private chats with business accounts, the opening hours of the business. Returned only in getChat. */
-    business_opening_hours?: BusinessOpeningHours;
-    /** For private chats, the personal channel of the user. Returned only in getChat. */
-    personal_chat?: Chat.ChannelChat;
-    /** Bio of the other party in a private chat. Returned only in getChat. */
-    bio?: string;
-    /** True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user. Returned only in getChat. */
-    has_private_forwards?: true;
-    /** True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat. Returned only in getChat. */
-    has_restricted_voice_and_video_messages?: true;
-  }
-  /** Internal type representing group chats returned from `getChat`. */
-  export interface GroupGetChat
-    extends GroupChat, GetChat, NonPrivateGetChat, MultiUserGetChat {}
-  /** Internal type representing supergroup chats returned from `getChat`. */
-  export interface SupergroupGetChat
-    extends
-      SupergroupChat,
-      GetChat,
-      NonGroupGetChat,
-      NonPrivateGetChat,
-      MultiUserGetChat,
-      LargeGetChat {
-    /** True, if users need to join the supergroup before they can send messages. Returned only in getChat. */
-    join_to_send_messages?: true;
-    /** True, if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in getChat. */
-    join_by_request?: true;
-    /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds. Returned only in getChat. */
-    slow_mode_delay?: number;
-    /** For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions. Returned only in getChat. */
-    unrestrict_boost_count?: number;
-    /** True, if new chat members will have access to old messages; available only to chat administrators. Returned only in getChat. */
-    has_visible_history?: boolean;
-    /** True, if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. Returned only in getChat. */
-    has_aggressive_anti_spam_enabled?: true;
-    /** For supergroups, name of group sticker set. Returned only in getChat. */
-    sticker_set_name?: string;
-    /** True, if the bot can change the group sticker set. Returned only in getChat. */
-    can_set_sticker_set?: true;
-    /** For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. Returned only in getChat. */
-    custom_emoji_sticker_set_name?: string;
-    /** For supergroups, the location to which the supergroup is connected. Returned only in getChat. */
-    location?: ChatLocation;
-  }
-  /** Internal type representing channel chats returned from `getChat`. */
-  export interface ChannelGetChat
-    extends
-      ChannelChat,
-      GetChat,
-      NonGroupGetChat,
-      NonPrivateGetChat,
-      NonMultiUserGetChat,
-      LargeGetChat {
-    /** Identifier of the accent color for the chat's profile background. See profile accent colors for more details. Returned only in getChat. */
-    profile_accent_color_id?: number;
-    /** Custom emoji identifier of the emoji chosen by the chat for its profile background. Returned only in getChat. */
-    profile_background_custom_emoji_id?: string;
+    /** Title, for supergroups, channels and group chats */
+    title: string;
+    /** Username, for private chats, supergroups and channels if available */
+    username?: string;
+    /** First name of the other party in a private chat */
+    first_name?: undefined;
+    /** Last name of the other party in a private chat */
+    last_name?: undefined;
+    /** True, if the supergroup chat is a forum (has topics enabled) */
+    is_forum?: undefined;
   }
 }
 
@@ -235,12 +141,373 @@ export type Chat =
   | Chat.SupergroupChat
   | Chat.ChannelChat;
 
-/** This object represents a Telegram user or bot that was returned by `getChat`. */
-export type ChatFromGetChat =
-  | Chat.PrivateGetChat
-  | Chat.GroupGetChat
-  | Chat.SupergroupGetChat
-  | Chat.ChannelGetChat;
+export declare namespace ChatFullInfo {
+  /** Internal type for private chats */
+  export interface PrivateChat {
+    /** Unique identifier for this chat. */
+    id: number;
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
+    type: "private";
+    /** Title, for supergroups, channels and group chats */
+    title?: undefined;
+    /**  Username, for private chats, supergroups and channels if available */
+    username?: string;
+    /**  First name of the other party in a private chat */
+    first_name: string;
+    /**  Last name of the other party in a private chat */
+    last_name?: string;
+    /** True, if the supergroup chat is a forum (has topics enabled) */
+    is_forum?: undefined;
+    /** Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. */
+    accent_color_id: number;
+    /** The maximum number of reactions that can be set on a message in the chat */
+    max_reaction_count: number;
+    /** Chat photo */
+    photo?: ChatPhoto;
+    /** If non-empty, the list of all active chat usernames; for private chats, supergroups and channels */
+    active_usernames?: string[];
+    /** For private chats, the date of birth of the user */
+    birthdate?: Birthdate;
+    /** For private chats with business accounts, the intro of the business */
+    business_intro?: BusinessIntro;
+    /** For private chats with business accounts, the location of the business */
+    business_location?: BusinessLocation;
+    /** For private chats with business accounts, the opening hours of the business */
+    business_opening_hours?: BusinessOpeningHours;
+    /** For private chats, the personal channel of the user */
+    personal_chat?: Chat;
+    /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. */
+    available_reactions?: ReactionType[];
+    /** Custom emoji identifier of the emoji chosen by the chat for the reply header and link preview background */
+    background_custom_emoji_id?: string;
+    /** Identifier of the accent color for the chat's profile background. See profile accent colors for more details. */
+    profile_accent_color_id?: number;
+    /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
+    profile_background_custom_emoji_id?: string;
+    /**  Custom emoji identifier of the emoji status of the chat or the other party in a private chat */
+    emoji_status_custom_emoji_id?: string;
+    /** Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any */
+    emoji_status_expiration_date?: number;
+    /** Bio of the other party in a private chat */
+    bio?: string;
+    /** True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user */
+    has_private_forwards?: true;
+    /** True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat */
+    has_restricted_voice_and_video_messages?: true;
+    /** True, if users need to join the supergroup before they can send messages */
+    join_to_send_messages?: undefined;
+    /** True, if all users directly joining the supergroup without using an invite link need to be approved by supergroup administrators */
+    join_by_request?: undefined;
+    /** Description, for groups, supergroups and channel chats */
+    description?: undefined;
+    /**  Primary invite link, for groups, supergroups and channel chats */
+    invite_link?: undefined;
+    /** The most recent pinned message (by sending date) */
+    pinned_message?: Message;
+    /** Default chat member permissions, for groups and supergroups */
+    permissions?: undefined;
+    /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds */
+    slow_mode_delay?: undefined;
+    /**  For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions */
+    unrestrict_boost_count?: undefined;
+    /**  The time after which all messages sent to the chat will be automatically deleted; in seconds */
+    message_auto_delete_time?: number;
+    /** True, if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. */
+    has_aggressive_anti_spam_enabled?: undefined;
+    /** True, if non-administrators can only get the list of bots and administrators in the chat */
+    has_hidden_members?: undefined;
+    /** True, if messages from the chat can't be forwarded to other chats */
+    has_protected_content?: true;
+    /** True, if new chat members will have access to old messages; available only to chat administrators */
+    has_visible_history?: undefined;
+    /** For supergroups, name of the group sticker set */
+    sticker_set_name?: undefined;
+    /** True, if the bot can change the group sticker set */
+    can_set_sticker_set?: undefined;
+    /** For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. */
+    custom_emoji_sticker_set_name?: undefined;
+    /** Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. */
+    linked_chat_id?: undefined;
+    /** For supergroups, the location to which the supergroup is connected */
+    location?: undefined;
+  }
+  /** Internal type for group chats */
+  export interface GroupChat {
+    /** Unique identifier for this chat. */
+    id: number;
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
+    type: "group";
+    /** Title, for supergroups, channels and group chats */
+    title?: string;
+    /**  Username, for private chats, supergroups and channels if available */
+    username?: undefined;
+    /**  First name of the other party in a private chat */
+    first_name?: undefined;
+    /**  Last name of the other party in a private chat */
+    last_name?: undefined;
+    /** True, if the supergroup chat is a forum (has topics enabled) */
+    is_forum?: undefined;
+    /** Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. */
+    accent_color_id: number;
+    /** The maximum number of reactions that can be set on a message in the chat */
+    max_reaction_count: number;
+    /** Chat photo */
+    photo?: ChatPhoto;
+    /** If non-empty, the list of all active chat usernames; for private chats, supergroups and channels */
+    active_usernames?: undefined;
+    /** For private chats, the date of birth of the user */
+    birthdate?: undefined;
+    /** For private chats with business accounts, the intro of the business */
+    business_intro?: undefined;
+    /** For private chats with business accounts, the location of the business */
+    business_location?: undefined;
+    /** For private chats with business accounts, the opening hours of the business */
+    business_opening_hours?: undefined;
+    /** For private chats, the personal channel of the user */
+    personal_chat?: undefined;
+    /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. */
+    available_reactions?: ReactionType[];
+    /** Custom emoji identifier of the emoji chosen by the chat for the reply header and link preview background */
+    background_custom_emoji_id?: string;
+    /** Identifier of the accent color for the chat's profile background. See profile accent colors for more details. */
+    profile_accent_color_id?: number;
+    /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
+    profile_background_custom_emoji_id?: string;
+    /**  Custom emoji identifier of the emoji status of the chat or the other party in a private chat */
+    emoji_status_custom_emoji_id?: string;
+    /** Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any */
+    emoji_status_expiration_date?: number;
+    /** Bio of the other party in a private chat */
+    bio?: undefined;
+    /** True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user */
+    has_private_forwards?: undefined;
+    /** True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat */
+    has_restricted_voice_and_video_messages?: undefined;
+    /** True, if users need to join the supergroup before they can send messages */
+    join_to_send_messages?: undefined;
+    /** True, if all users directly joining the supergroup without using an invite link need to be approved by supergroup administrators */
+    join_by_request?: undefined;
+    /** Description, for groups, supergroups and channel chats */
+    description?: string;
+    /**  Primary invite link, for groups, supergroups and channel chats */
+    invite_link?: string;
+    /** The most recent pinned message (by sending date) */
+    pinned_message?: Message;
+    /** Default chat member permissions, for groups and supergroups */
+    permissions?: ChatPermissions;
+    /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds */
+    slow_mode_delay?: undefined;
+    /**  For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions */
+    unrestrict_boost_count?: undefined;
+    /**  The time after which all messages sent to the chat will be automatically deleted; in seconds */
+    message_auto_delete_time?: number;
+    /** True, if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. */
+    has_aggressive_anti_spam_enabled?: undefined;
+    /** True, if non-administrators can only get the list of bots and administrators in the chat */
+    has_hidden_members?: true;
+    /** True, if messages from the chat can't be forwarded to other chats */
+    has_protected_content?: true;
+    /** True, if new chat members will have access to old messages; available only to chat administrators */
+    has_visible_history?: true;
+    /** For supergroups, name of the group sticker set */
+    sticker_set_name?: undefined;
+    /** True, if the bot can change the group sticker set */
+    can_set_sticker_set?: true;
+    /** For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. */
+    custom_emoji_sticker_set_name?: undefined;
+    /** Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. */
+    linked_chat_id?: undefined;
+    /** For supergroups, the location to which the supergroup is connected */
+    location?: undefined;
+  }
+  /** Internal type for supergroup chats */
+  export interface SupergroupChat {
+    /** Unique identifier for this chat. */
+    id: number;
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
+    type: "supergroup";
+    /** Title, for supergroups, channels and group chats */
+    title?: string;
+    /**  Username, for private chats, supergroups and channels if available */
+    username?: string;
+    /**  First name of the other party in a private chat */
+    first_name?: undefined;
+    /**  Last name of the other party in a private chat */
+    last_name?: undefined;
+    /** True, if the supergroup chat is a forum (has topics enabled) */
+    is_forum?: true;
+    /** Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. */
+    accent_color_id: number;
+    /** The maximum number of reactions that can be set on a message in the chat */
+    max_reaction_count: number;
+    /** Chat photo */
+    photo?: ChatPhoto;
+    /** If non-empty, the list of all active chat usernames; for private chats, supergroups and channels */
+    active_usernames?: string[];
+    /** For private chats, the date of birth of the user */
+    birthdate?: undefined;
+    /** For private chats with business accounts, the intro of the business */
+    business_intro?: undefined;
+    /** For private chats with business accounts, the location of the business */
+    business_location?: undefined;
+    /** For private chats with business accounts, the opening hours of the business */
+    business_opening_hours?: undefined;
+    /** For private chats, the personal channel of the user */
+    personal_chat?: undefined;
+    /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. */
+    available_reactions?: ReactionType[];
+    /** Custom emoji identifier of the emoji chosen by the chat for the reply header and link preview background */
+    background_custom_emoji_id?: string;
+    /** Identifier of the accent color for the chat's profile background. See profile accent colors for more details. */
+    profile_accent_color_id?: number;
+    /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
+    profile_background_custom_emoji_id?: string;
+    /**  Custom emoji identifier of the emoji status of the chat or the other party in a private chat */
+    emoji_status_custom_emoji_id?: string;
+    /** Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any */
+    emoji_status_expiration_date?: number;
+    /** Bio of the other party in a private chat */
+    bio?: string;
+    /** True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user */
+    has_private_forwards?: undefined;
+    /** True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat */
+    has_restricted_voice_and_video_messages?: undefined;
+    /** True, if users need to join the supergroup before they can send messages */
+    join_to_send_messages?: true;
+    /** True, if all users directly joining the supergroup without using an invite link need to be approved by supergroup administrators */
+    join_by_request?: true;
+    /** Description, for groups, supergroups and channel chats */
+    description?: string;
+    /**  Primary invite link, for groups, supergroups and channel chats */
+    invite_link?: string;
+    /** The most recent pinned message (by sending date) */
+    pinned_message?: Message;
+    /** Default chat member permissions, for groups and supergroups */
+    permissions?: ChatPermissions;
+    /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds */
+    slow_mode_delay?: number;
+    /**  For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions */
+    unrestrict_boost_count?: number;
+    /**  The time after which all messages sent to the chat will be automatically deleted; in seconds */
+    message_auto_delete_time?: number;
+    /** True, if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. */
+    has_aggressive_anti_spam_enabled?: true;
+    /** True, if non-administrators can only get the list of bots and administrators in the chat */
+    has_hidden_members?: true;
+    /** True, if messages from the chat can't be forwarded to other chats */
+    has_protected_content?: true;
+    /** True, if new chat members will have access to old messages; available only to chat administrators */
+    has_visible_history?: true;
+    /** For supergroups, name of the group sticker set */
+    sticker_set_name?: string;
+    /** True, if the bot can change the group sticker set */
+    can_set_sticker_set?: true;
+    /** For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. */
+    custom_emoji_sticker_set_name?: string;
+    /** Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. */
+    linked_chat_id?: number;
+    /** For supergroups, the location to which the supergroup is connected */
+    location?: ChatLocation;
+  }
+  /** Internal type for channel chats */
+  export interface ChannelChat {
+    /** Unique identifier for this chat. */
+    id: number;
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
+    type: "channel";
+    /** Title, for supergroups, channels and group chats */
+    title?: string;
+    /**  Username, for private chats, supergroups and channels if available */
+    username?: string;
+    /**  First name of the other party in a private chat */
+    first_name?: undefined;
+    /**  Last name of the other party in a private chat */
+    last_name?: undefined;
+    /** True, if the supergroup chat is a forum (has topics enabled) */
+    is_forum?: undefined;
+    /** Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. */
+    accent_color_id: number;
+    /** The maximum number of reactions that can be set on a message in the chat */
+    max_reaction_count: number;
+    /** Chat photo */
+    photo?: ChatPhoto;
+    /** If non-empty, the list of all active chat usernames; for private chats, supergroups and channels */
+    active_usernames?: string[];
+    /** For private chats, the date of birth of the user */
+    birthdate?: undefined;
+    /** For private chats with business accounts, the intro of the business */
+    business_intro?: undefined;
+    /** For private chats with business accounts, the location of the business */
+    business_location?: undefined;
+    /** For private chats with business accounts, the opening hours of the business */
+    business_opening_hours?: undefined;
+    /** For private chats, the personal channel of the user */
+    personal_chat?: undefined;
+    /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. */
+    available_reactions?: ReactionType[];
+    /** Custom emoji identifier of the emoji chosen by the chat for the reply header and link preview background */
+    background_custom_emoji_id?: string;
+    /** Identifier of the accent color for the chat's profile background. See profile accent colors for more details. */
+    profile_accent_color_id?: number;
+    /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
+    profile_background_custom_emoji_id?: string;
+    /**  Custom emoji identifier of the emoji status of the chat or the other party in a private chat */
+    emoji_status_custom_emoji_id?: string;
+    /** Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any */
+    emoji_status_expiration_date?: number;
+    /** Bio of the other party in a private chat */
+    bio?: undefined;
+    /** True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user */
+    has_private_forwards?: undefined;
+    /** True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat */
+    has_restricted_voice_and_video_messages?: undefined;
+    /** True, if users need to join the supergroup before they can send messages */
+    join_to_send_messages?: true;
+    /** True, if all users directly joining the supergroup without using an invite link need to be approved by supergroup administrators */
+    join_by_request?: undefined;
+    /** Description, for groups, supergroups and channel chats */
+    description?: string;
+    /**  Primary invite link, for groups, supergroups and channel chats */
+    invite_link?: string;
+    /** The most recent pinned message (by sending date) */
+    pinned_message?: Message;
+    /** Default chat member permissions, for groups and supergroups */
+    permissions?: undefined;
+    /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds */
+    slow_mode_delay?: undefined;
+    /**  For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions */
+    unrestrict_boost_count?: undefined;
+    /**  The time after which all messages sent to the chat will be automatically deleted; in seconds */
+    message_auto_delete_time?: number;
+    /** True, if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. */
+    has_aggressive_anti_spam_enabled?: undefined;
+    /** True, if non-administrators can only get the list of bots and administrators in the chat */
+    has_hidden_members?: undefined;
+    /** True, if messages from the chat can't be forwarded to other chats */
+    has_protected_content?: true;
+    /** True, if new chat members will have access to old messages; available only to chat administrators */
+    has_visible_history?: undefined;
+    /** For supergroups, name of the group sticker set */
+    sticker_set_name?: undefined;
+    /** True, if the bot can change the group sticker set */
+    can_set_sticker_set?: undefined;
+    /** For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. */
+    custom_emoji_sticker_set_name?: undefined;
+    /** Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. */
+    linked_chat_id?: number;
+    /** For supergroups, the location to which the supergroup is connected */
+    location?: undefined;
+  }
+}
+
+/** This object contains full information about a chat. */
+export type ChatFullInfo =
+  | ChatFullInfo.PrivateChat
+  | ChatFullInfo.GroupChat
+  | ChatFullInfo.SupergroupChat
+  | ChatFullInfo.ChannelChat;
+/** @deprecated use ChatFullInfo instead */
+export type ChatFromGetChat = ChatFullInfo;
 
 /** This object represent a user's profile pictures. */
 export interface UserProfilePhotos {
@@ -304,7 +571,7 @@ export interface ChatAdministratorRights {
   can_invite_users: boolean;
   /** True, if the administrator can post stories to the chat */
   can_post_stories: boolean;
-  /** True, if the administrator can edit stories posted by other users */
+  /** True, if the administrator can edit stories posted by other users, post stories to the chat page, pin chat stories, and access the chat's story archive */
   can_edit_stories: boolean;
   /** True, if the administrator can delete stories posted by other users */
   can_delete_stories: boolean;
@@ -332,6 +599,8 @@ export interface ChatMemberUpdated {
   new_chat_member: ChatMember;
   /** Chat invite link, which was used by the user to join the chat; for joining by invite link events only. */
   invite_link?: ChatInviteLink;
+  /** True, if the user joined the chat after sending a direct join request without using an invite link without using an invite link and being approved by an administrator */
+  via_join_request?: boolean;
   /** True, if the user joined the chat via a chat folder invite link */
   via_chat_folder_invite_link?: boolean;
 }
@@ -389,7 +658,7 @@ export interface ChatMemberAdministrator {
   can_invite_users: boolean;
   /** True, if the administrator can post stories to the chat */
   can_post_stories: boolean;
-  /** True, if the administrator can edit stories posted by other users */
+  /** True, if the administrator can edit stories posted by other users, post stories to the chat page, pin chat stories, and access the chat's story archive */
   can_edit_stories: boolean;
   /** True, if the administrator can delete stories posted by other users */
   can_delete_stories: boolean;
@@ -519,6 +788,7 @@ export interface ChatPermissions {
   can_manage_topics?: boolean;
 }
 
+/** Describes the birthdate of a user. */
 export interface Birthdate {
   /** Day of the user's birth; 1-31 */
   day: number;
@@ -528,6 +798,7 @@ export interface Birthdate {
   year?: number;
 }
 
+/** Contains information about the start page settings of a Telegram Business account. */
 export interface BusinessIntro {
   /** Title text of the business intro */
   title?: string;
@@ -537,6 +808,7 @@ export interface BusinessIntro {
   sticker?: Sticker;
 }
 
+/** Contains information about the location of a Telegram Business account. */
 export interface BusinessLocation {
   /** Address of the business */
   address: string;
@@ -544,13 +816,15 @@ export interface BusinessLocation {
   location?: Location;
 }
 
+/** Describes an interval of time during which a business is open. */
 export interface BusinessOpeningHoursInterval {
-  /** The minute's sequence number in a week, starting on Monday, marking the start of the time interval during which the business is open; 0 - 7 24 60 */
+  /** The minute's sequence number in a week, starting on Monday, marking the start of the time interval during which the business is open; 0 - 7 * 24 * 60 */
   opening_minute: number;
-  /** The minute's sequence number in a week, starting on Monday, marking the end of the time interval during which the business is open; 0 - 8 24 60 */
+  /** The minute's sequence number in a week, starting on Monday, marking the end of the time interval during which the business is open; 0 - 8 * 24 * 60 */
   closing_minute: number;
 }
 
+/** Describes the opening hours of a business. */
 export interface BusinessOpeningHours {
   /** Unique name of the time zone for which the opening hours are defined */
   time_zone_name: string;
@@ -684,6 +958,6 @@ export interface BusinessMessagesDeleted {
   business_connection_id: string;
   /** Information about a chat in the business account. The bot may not have access to the chat or the corresponding user. */
   chat: Chat.PrivateChat;
-  /** A JSON-serialized list of identifiers of deleted messages in the chat of the business account */
+  /** The list of identifiers of deleted messages in the chat of the business account */
   message_ids: number[];
 }

--- a/markup.ts
+++ b/markup.ts
@@ -17,11 +17,11 @@ export declare namespace InlineKeyboardButton {
     url: string;
   }
   export interface CallbackButton extends AbstractInlineKeyboardButton {
-    /** Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes */
+    /** Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes. Not supported for messages sent on behalf of a Telegram Business account. */
     callback_data: string;
   }
   export interface WebAppButton extends AbstractInlineKeyboardButton {
-    /** Description of the Web App that will be launched when the user presses the button. The Web App will be able to send an arbitrary message on behalf of the user using the method answerWebAppQuery. Available only in private chats between a user and the bot. */
+    /** Description of the Web App that will be launched when the user presses the button. The Web App will be able to send an arbitrary message on behalf of the user using the method answerWebAppQuery. Available only in private chats between a user and the bot. Not supported for messages sent on behalf of a Telegram Business account. */
     web_app: WebAppInfo;
   }
   export interface LoginButton extends AbstractInlineKeyboardButton {
@@ -29,19 +29,19 @@ export declare namespace InlineKeyboardButton {
     login_url: LoginUrl;
   }
   export interface SwitchInlineButton extends AbstractInlineKeyboardButton {
-    /** If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. Can be empty, in which case just the bot's username will be inserted. */
+    /** If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. May be empty, in which case just the bot's username will be inserted. Not supported for messages sent on behalf of a Telegram Business account. */
     switch_inline_query: string;
   }
   export interface SwitchInlineCurrentChatButton
     extends AbstractInlineKeyboardButton {
     /** If set, pressing the button will insert the bot's username and the specified inline query in the current chat's input field. Can be empty, in which case only the bot's username will be inserted.
 
-    This offers a quick way for the user to open your bot in inline mode in the same chat – good for selecting something from multiple options. */
+    This offers a quick way for the user to open your bot in inline mode in the same chat – good for selecting something from multiple options. Not supported in channels and for messages sent on behalf of a Telegram Business account. */
     switch_inline_query_current_chat: string;
   }
   export interface SwitchInlineChosenChatButton
     extends AbstractInlineKeyboardButton {
-    /** If set, pressing the button will prompt the user to select one of their chats of the specified type, open that chat and insert the bot's username and the specified inline query in the input field */
+    /** If set, pressing the button will prompt the user to select one of their chats of the specified type, open that chat and insert the bot's username and the specified inline query in the input field. Not supported for messages sent on behalf of a Telegram Business account. */
     switch_inline_query_chosen_chat: SwitchInlineQueryChosenChat;
   }
   export interface GameButton extends AbstractInlineKeyboardButton {
@@ -122,7 +122,7 @@ export interface CallbackQuery {
   game_short_name?: string;
 }
 
-/** This object represents a custom keyboard with reply options (see Introduction to bots for details and examples). */
+/** This object represents a custom keyboard with reply options (see Introduction to bots for details and examples). Not supported in channels and for messages sent on behalf of a Telegram Business account. */
 export interface ReplyKeyboardMarkup {
   /** Array of button rows, each represented by an Array of KeyboardButton objects */
   keyboard: KeyboardButton[][];
@@ -188,7 +188,7 @@ export interface KeyboardButtonPollType {
   type?: "quiz" | "regular";
 }
 
-/** Upon receiving a message with this object, Telegram clients will remove the current custom keyboard and display the default letter-keyboard. By default, custom keyboards are displayed until a new keyboard is sent by a bot. An exception is made for one-time keyboards that are hidden immediately after the user presses a button (see ReplyKeyboardMarkup). */
+/** Upon receiving a message with this object, Telegram clients will remove the current custom keyboard and display the default letter-keyboard. By default, custom keyboards are displayed until a new keyboard is sent by a bot. An exception is made for one-time keyboards that are hidden immediately after the user presses a button (see ReplyKeyboardMarkup). Not supported in channels and for messages sent on behalf of a Telegram Business account. */
 export interface ReplyKeyboardRemove {
   /** Requests clients to remove the custom keyboard (user will not be able to summon this keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in ReplyKeyboardMarkup) */
   remove_keyboard: true;
@@ -198,7 +198,7 @@ export interface ReplyKeyboardRemove {
   selective?: boolean;
 }
 
-/** Upon receiving a message with this object, Telegram clients will display a reply interface to the user (act as if the user has selected the bot's message and tapped 'Reply'). This can be extremely useful if you want to create user-friendly step-by-step interfaces without having to sacrifice privacy mode.
+/** Upon receiving a message with this object, Telegram clients will display a reply interface to the user (act as if the user has selected the bot's message and tapped 'Reply'). This can be extremely useful if you want to create user-friendly step-by-step interfaces without having to sacrifice privacy mode. Not supported in channels and for messages sent on behalf of a Telegram Business account.
 
 Example: A poll bot for groups runs in privacy mode (only receives commands, replies to its messages and mentions). There could be two ways to create a new poll:
 
@@ -232,11 +232,11 @@ export interface KeyboardButtonRequestUsers {
   user_is_premium?: boolean;
   /** The maximum number of users to be selected; 1-10. Defaults to 1. */
   max_quantity?: number;
-  /** Pass True to request the users' first and last name */
+  /** Pass True to request the users' first and last names */
   request_name?: boolean;
-  /** Pass True to request the users' username */
+  /** Pass True to request the users' usernames */
   request_username?: boolean;
-  /** Pass True to request the users' photo */
+  /** Pass True to request the users' photos */
   request_photo?: boolean;
 }
 

--- a/message.ts
+++ b/message.ts
@@ -135,6 +135,9 @@ export declare namespace Message {
   export type BoostAddedMessage =
     & ServiceMessage
     & MsgWith<"boost_added">;
+  export type ChatBackgroundSetMessage =
+    & ServiceMessage
+    & MsgWith<"chat_background_set">;
   export type ForumTopicCreatedMessage =
     & ServiceMessage
     & MsgWith<"forum_topic_created">;
@@ -257,6 +260,8 @@ export interface Message extends Message.MediaMessage {
   proximity_alert_triggered?: ProximityAlertTriggered;
   /** Service message: user boosted the chat */
   boost_added?: ChatBoostAdded;
+  /* Service message: chat background set */
+  chat_background_set?: ChatBackground;
   /** Service message: forum topic created */
   forum_topic_created?: ForumTopicCreated;
   /** Service message: forum topic edited */
@@ -321,6 +326,7 @@ export interface InaccessibleMessage extends
 }
 
 /** This object describes a message that can be inaccessible to the bot. It can be one of
+
 - Message
 - InaccessibleMessage */
 export type MaybeInaccessibleMessage = Message | InaccessibleMessage;
@@ -568,6 +574,7 @@ export interface ReplyParameters {
 }
 
 /** This object describes the origin of a message. It can be one of
+
 - MessageOriginUser
 - MessageOriginHiddenUser
 - MessageOriginChat
@@ -698,6 +705,14 @@ export interface Document {
   file_size?: number;
 }
 
+/** This object represents a story. */
+export interface Story {
+  /** Chat that posted the story */
+  chat: Chat;
+  /** Unique identifier for the story in the chat */
+  id: number;
+}
+
 /** This object represents a video file. */
 export interface Video {
   /** Identifier for this file, which can be used to download or reuse the file */
@@ -776,8 +791,20 @@ export interface Dice {
 export interface PollOption {
   /** Option text, 1-100 characters */
   text: string;
+  /** Special entities that appear in the option text. Currently, only custom emoji entities are allowed in poll option texts */
+  text_entities?: MessageEntity[];
   /** Number of users that voted for this option */
   voter_count: number;
+}
+
+/** This object contains information about one answer option in a poll to send. */
+export interface InputPollOption {
+  /** Option text, 1-100 characters */
+  text: string;
+  /** Mode for parsing entities in the text. See formatting options for more details. Currently, only custom emoji entities are allowed */
+  text_parse_mode?: string;
+  /** A list of special entities that appear in the poll option text. It can be specified instead of text_parse_mode */
+  text_entities?: MessageEntity[];
 }
 
 /** This object represents an answer of a user in a non-anonymous poll. */
@@ -798,6 +825,8 @@ export interface Poll {
   id: string;
   /** Poll question, 1-300 characters */
   question: string;
+  /** Special entities that appear in the question. Currently, only custom emoji entities are allowed in poll questions */
+  question_entities?: MessageEntity[];
   /** List of poll options */
   options: PollOption[];
   /** Total number of users that voted in the poll */
@@ -856,12 +885,12 @@ export interface Venue {
   google_place_type?: string;
 }
 
-/** This object represents a story. */
-export interface Story {
-  /** Chat that posted the story */
-  chat: Chat;
-  /** Unique identifier for the story in the chat */
-  id: number;
+/** Describes data sent from a Web App to the bot. */
+export interface WebAppData {
+  /** The data. Be aware that a bad client can send arbitrary data in this field. */
+  data: string;
+  /** Text of the web_app keyboard button from which the Web App was opened. Be aware that a bad client can send arbitrary data in this field. */
+  button_text: string;
 }
 
 /** This object represents the content of a service message, sent whenever a user in the chat triggers a proximity alert set by another user. */
@@ -878,6 +907,117 @@ export interface ProximityAlertTriggered {
 export interface MessageAutoDeleteTimerChanged {
   /** New auto-delete time for messages in the chat; in seconds */
   message_auto_delete_time: number;
+}
+
+/** This object represents a service message about a user boosting a chat. */
+export interface ChatBoostAdded {
+  /** Number of boosts added by the user */
+  boost_count: number;
+}
+
+/** This object describes the way a background is filled based on the selected colors. Currently, it can be one of
+
+- BackgroundFillSolid
+- BackgroundFillGradient
+- BackgroundFillFreeformGradient */
+export type BackgroundFill =
+  | BackgroundFillSolid
+  | BackgroundFillGradient
+  | BackgroundFillFreeformGradient;
+
+/** The background is filled using the selected color. */
+export interface BackgroundFillSolid {
+  /** Type of the background fill, always “solid” */
+  type: "solid";
+  /** The color of the background fill in the RGB24 format */
+  color: number;
+}
+
+/** The background is a gradient fill. */
+export interface BackgroundFillGradient {
+  /** Type of the background fill, always “gradient” */
+  type: "gradient";
+  /** Top color of the gradient in the RGB24 format */
+  top_color: number;
+  /** Bottom color of the gradient in the RGB24 format */
+  bottom_color: number;
+  /** Clockwise rotation angle of the background fill in degrees; 0-359 */
+  rotation_angle: number;
+}
+
+/** The background is a freeform gradient that rotates  after every message in the chat. */
+export interface BackgroundFillFreeformGradient {
+  /** Type of the background fill, always “freeform_gradient” */
+  type: "freeform_gradient";
+  /** A list of the 3 or 4 base colors that are used to generate the freeform gradient in the RGB24 format */
+  colors: number[];
+}
+
+/** This object describes the type of a background. Currently, it can be one of
+
+- BackgroundTypeFill
+- BackgroundTypeWallpaper
+- BackgroundTypePattern
+- BackgroundTypeChatTheme
+- BackgroundTypeFill */
+export type BackgroundType =
+  | BackgroundTypeFill
+  | BackgroundTypeWallpaper
+  | BackgroundTypePattern
+  | BackgroundTypeChatTheme;
+
+/** The background is automatically filled based on the selected colors. */
+export interface BackgroundTypeFill {
+  /** Type of the background, always “fill” */
+  type: "fill";
+  /** The background fill */
+  fill: BackgroundFill;
+  /** Dimming of the background in dark themes, as a percentage; 0-100 */
+  dark_theme_dimming: number;
+}
+
+/** The background is a wallpaper in the JPEG format. */
+export interface BackgroundTypeWallpaper {
+  /** Type of the background, always “wallpaper” */
+  type: "wallpaper";
+  /** Document with the wallpaper */
+  document: Document;
+  /** Dimming of the background in dark themes, as a percentage; 0-100 */
+  dark_theme_dimming: number;
+  /** True, if the wallpaper is downscaled to fit in a 450x450 square and then box-blurred with radius 12 */
+  is_blurred?: true;
+  /** True, if the background moves slightly when the device is tilted */
+  is_moving?: true;
+}
+
+/** The background is a PNG or TGV (gzipped subset of SVG with MIME type “application/x-tgwallpattern”) pattern to be combined with the background fill chosen by the user. */
+export interface BackgroundTypePattern {
+  /** Type of the background, always “pattern” */
+  type: "pattern";
+  /** Document with the pattern */
+  document: Document;
+  /** The background fill that is combined with the pattern */
+  fill: BackgroundFill;
+  /** Intensity of the pattern when it is shown above the filled background; 0-100 */
+  intensity: number;
+  /** True, if the background fill must be applied only to the pattern itself. All other pixels are black in this case. For dark themes only */
+  is_inverted?: true;
+  /** True, if the background moves slightly when the device is tilted */
+  is_moving?: true;
+}
+
+/** The background is taken directly from a built-in chat  theme. */
+export interface BackgroundTypeChatTheme {
+  /** Type of the background, always “chat_theme” */
+  type: "chat_theme";
+  /** Name of the chat theme, which is usually an emoji */
+  theme_name: string;
+}
+
+/** This object represents a chat background. */
+export interface ChatBackground {
+  /** Type of the background*/
+  type: BackgroundType;
 }
 
 /** This object represents a service message about a new forum topic created in the chat. */
@@ -910,15 +1050,9 @@ export interface GeneralForumTopicHidden {}
 /** This object represents a service message about General forum topic unhidden in the chat. Currently holds no information. */
 export interface GeneralForumTopicUnhidden {}
 
-/** This object represents a service message about a user boosting a chat. */
-export interface ChatBoostAdded {
-  /** Number of boosts added by the user */
-  boost_count: number;
-}
-
-/** This object contains information about a user that was shared with the bot using a KeyboardButtonRequestUser button. */
+/** This object contains information about a user that was shared with the bot using a KeyboardButtonRequestUsers button. */
 export interface SharedUser {
-  /** Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means. */
+  /** Identifier of the shared user. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means. */
   user_id: number;
   /** First name of the user, if the name was requested by the bot */
   first_name?: string;
@@ -1056,14 +1190,6 @@ export interface LinkPreviewOptions {
   show_above_text?: boolean;
 }
 
-/** Describes data sent from a Web App to the bot. */
-export interface WebAppData {
-  /** The data. Be aware that a bad client can send arbitrary data in this field. */
-  data: string;
-  /** Text of the web_app keyboard button from which the Web App was opened. Be aware that a bad client can send arbitrary data in this field. */
-  button_text: string;
-}
-
 /** This object represents a sticker. */
 export interface Sticker {
   /** Identifier for this file, which can be used to download or reuse the file */
@@ -1160,7 +1286,10 @@ export interface File {
   file_path?: string;
 }
 
-/** This object describes the type of a reaction. Currently, it can be one of */
+/** This object describes the type of a reaction. Currently, it can be one of
+
+- ReactionTypeEmoji
+- ReactionTypeCustomEmoji */
 export type ReactionType = ReactionTypeEmoji | ReactionTypeCustomEmoji;
 
 /** The reaction is based on an emoji. */

--- a/methods.ts
+++ b/methods.ts
@@ -16,6 +16,7 @@ import type {
   UserProfilePhotos,
   WebhookInfo,
 } from "./manage.ts";
+import { ChatFullInfo } from "./manage.ts";
 import type {
   ForceReply,
   InlineKeyboardMarkup,
@@ -147,7 +148,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -263,7 +264,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -305,7 +306,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -341,7 +342,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -385,7 +386,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -427,7 +428,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -437,7 +438,7 @@ export type ApiMethods<F> = {
     reply_to_message_id?: number;
   }): Message.AnimationMessage;
 
-  /** Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future. */
+  /** Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future. */
   sendVoice(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
@@ -461,7 +462,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -494,7 +495,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -548,7 +549,7 @@ export type ApiMethods<F> = {
     longitude: number;
     /** The radius of uncertainty for the location, measured in meters; 0-1500 */
     horizontal_accuracy?: number;
-    /** Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400. */
+    /** Period in seconds during which the location will be updated (see Live Locations, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely. */
     live_period?: number;
     /** The direction in which user is moving, in degrees; 1-360. For active live locations only. */
     heading?: number;
@@ -560,7 +561,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -582,6 +583,8 @@ export type ApiMethods<F> = {
     latitude: number;
     /** Longitude of new location */
     longitude: number;
+    /** New period in seconds during which the location can be updated, starting from the message send date. If 0x7FFFFFFF is specified, then the location can be updated forever. Otherwise, the new value must not exceed the current live_period by more than a day, and the live location expiration date must remain within the next 90 days. If not specified, then live_period remains unchanged */
+    live_period?: number;
     /** The radius of uncertainty for the location, measured in meters; 0-1500 */
     horizontal_accuracy?: number;
     /** The direction in which user is moving, in degrees; 1-360. For active live locations only. */
@@ -634,7 +637,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -666,7 +669,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -686,8 +689,12 @@ export type ApiMethods<F> = {
     message_thread_id?: number;
     /** Poll question, 1-300 characters */
     question: string;
-    /** A list of answer options, 2-10 strings 1-100 characters each */
-    options: readonly string[];
+    /** Mode for parsing entities in the question. See formatting options for more details. Currently, only custom emoji entities are allowed */
+    question_parse_mode?: string;
+    /** A list of special entities that appear in the poll question. It can be specified instead of question_parse_mode */
+    question_entities?: MessageEntity[];
+    /** A list of 2-10 answer options */
+    options: InputPollOption[];
     /** True, if the poll needs to be anonymous, defaults to True */
     is_anonymous?: boolean;
     /** Poll type, “quiz” or “regular”, defaults to “regular” */
@@ -700,7 +707,7 @@ export type ApiMethods<F> = {
     explanation?: string;
     /** Mode for parsing entities in the explanation. See formatting options for more details. */
     explanation_parse_mode?: ParseMode;
-    /** A list of special entities that appear in the poll explanation, which can be specified instead of parse_mode */
+    /** A list of special entities that appear in the poll explanation. It can be specified instead of explanation_parse_mode */
     explanation_entities?: MessageEntity[];
     /** Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date. */
     open_period?: number;
@@ -714,7 +721,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -740,7 +747,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -871,7 +878,7 @@ export type ApiMethods<F> = {
     can_invite_users?: boolean;
     /** True if the administrator can post stories to the chat */
     can_post_stories?: boolean;
-    /** True if the administrator can edit stories posted by other users */
+    /** Pass True if the administrator can edit stories posted by other users, post stories to the chat page, pin chat stories, and access the chat's story archive */
     can_edit_stories?: boolean;
     /** True if the administrator can delete stories posted by other users */
     can_delete_stories?: boolean;
@@ -1043,11 +1050,11 @@ export type ApiMethods<F> = {
     chat_id: number | string;
   }): true;
 
-  /** Use this method to get up to date information about the chat. Returns a Chat object on success. */
+  /** Use this method to get up-to-date information about the chat. Returns a ChatFullInfo object on success. */
   getChat(args: {
     /** Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername) */
     chat_id: number | string;
-  }): ChatFromGetChat;
+  }): ChatFullInfo;
 
   /** Use this method to get a list of administrators in a chat, which aren't bots. Returns an Array of ChatMember objects. */
   getChatAdministrators(args: {
@@ -1434,7 +1441,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account. */
+    /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. */
     reply_markup?:
       | InlineKeyboardMarkup
       | ReplyKeyboardMarkup
@@ -1755,7 +1762,7 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
-    /** An object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game. Not supported for messages sent on behalf of a business account. */
+    /** An object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game. */
     reply_markup?: InlineKeyboardMarkup;
     /** @deprecated Use `reply_parameters` instead. */
     reply_to_message_id?: number;

--- a/methods.ts
+++ b/methods.ts
@@ -26,6 +26,7 @@ import type {
 import type {
   File,
   GameHighScore,
+  InputPollOption,
   LinkPreviewOptions,
   MaskPosition,
   Message,

--- a/methods.ts
+++ b/methods.ts
@@ -16,7 +16,7 @@ import type {
   UserProfilePhotos,
   WebhookInfo,
 } from "./manage.ts";
-import { ChatFullInfo } from "./manage.ts";
+import type { ChatFullInfo } from "./manage.ts";
 import type {
   ForceReply,
   InlineKeyboardMarkup,

--- a/update.ts
+++ b/update.ts
@@ -56,7 +56,7 @@ export interface Update {
   edited_channel_post?: Message & Update.Edited & Update.Channel;
   /** The bot was connected to or disconnected from a business account, or a user edited an existing connection with the bot */
   business_connection?: BusinessConnection;
-  /** New non-service message from a connected business account */
+  /** New message from a connected business account */
   business_message?: Message & Update.Private;
   /** New version of a message from a connected business account */
   edited_business_message?: Message & Update.Edited & Update.Private;


### PR DESCRIPTION
Updates all types to Bot API 7.3.

Also refactors the `Chat` objects.

Previously, you needed to check `chat.type` before accessing any of the properties. This was done by having a complex hierarchy of snippets of chat objects. It was hard to maintain and heavily relied on multiple inheritance. This PQ fixes both the usability and the maintainability by adding redundancy. There are now 4 chat objects that all share the identical set of properties, and the presence/absence of these fields is done for each chat type.

In addition, `ChatFromGetChat` was deprecated in favour of `ChatFullInfo`. This newly introduced abstraction follows the same above pattern.