### PR TITLE
Updated a few parse modes that were typed as string

### DIFF
--- a/message.ts
+++ b/message.ts
@@ -589,7 +589,7 @@ export interface ReplyParameters {
   /** Quoted part of the message to be replied to; 0-1024 characters after entities parsing. The quote must be an exact substring of the message to be replied to, including bold, italic, underline, strikethrough, spoiler, and custom_emoji entities. The message will fail to send if the quote isn't found in the original message. */
   quote?: string;
   /** Mode for parsing entities in the quote. See formatting options for more details. */
-  quote_parse_mode?: string;
+  quote_parse_mode?: ParseMode;
   /** A JSON-serialized list of special entities that appear in the quote. It can be specified instead of quote_parse_mode. */
   quote_entities?: MessageEntity[];
   /** Position of the quote in the original message in UTF-16 code units */
@@ -825,7 +825,7 @@ export interface InputPollOption {
   /** Option text, 1-100 characters */
   text: string;
   /** Mode for parsing entities in the text. See formatting options for more details. Currently, only custom emoji entities are allowed */
-  text_parse_mode?: string;
+  text_parse_mode?: ParseMode;
   /** A list of special entities that appear in the poll option text. It can be specified instead of text_parse_mode */
   text_entities?: MessageEntity[];
 }

--- a/methods.ts
+++ b/methods.ts
@@ -214,7 +214,7 @@ export type ApiMethods<F> = {
     /** New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept */
     caption?: string;
     /** Mode for parsing entities in the new caption. See formatting options for more details. */
-    parse_mode?: string;
+    parse_mode?: ParseMode;
     /** A list of special entities that appear in the new caption, which can be specified instead of parse_mode */
     caption_entities?: MessageEntity[];
     /** Pass True, if the caption must be shown above the message media. Ignored if a new caption isn't specified. */
@@ -683,7 +683,7 @@ export type ApiMethods<F> = {
     /** Media caption, 0-1024 characters after entities parsing */
     caption?: string;
     /** Mode for parsing entities in the media caption. See formatting options for more details. */
-    parse_mode?: string;
+    parse_mode?: ParseMode;
     /** A list of special entities that appear in the caption, which can be specified instead of parse_mode */
     caption_entities?: MessageEntity[];
     /** Pass True, if the caption must be shown above the message media */
@@ -795,7 +795,7 @@ export type ApiMethods<F> = {
     /** Poll question, 1-300 characters */
     question: string;
     /** Mode for parsing entities in the question. See formatting options for more details. Currently, only custom emoji entities are allowed */
-    question_parse_mode?: string;
+    question_parse_mode?: ParseMode;
     /** A list of special entities that appear in the poll question. It can be specified instead of question_parse_mode */
     question_entities?: MessageEntity[];
     /** A list of 2-10 answer options */


### PR DESCRIPTION
There should be none left typed as string.