### PR TITLE
Fix accepted_gift_types in Group and Channel Chats

### DIFF
--- a/manage.ts
+++ b/manage.ts
@@ -313,8 +313,8 @@ export declare namespace ChatFullInfo {
     pinned_message?: Message;
     /** Default chat member permissions, for groups and supergroups */
     permissions?: ChatPermissions;
-    /** True, if gifts can be sent to the chat */
-    can_send_gift?: true;
+    /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
+    accepted_gift_types: AcceptedGiftTypes;
     /** True, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats. */
     can_send_paid_media?: undefined;
     /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds */
@@ -406,8 +406,8 @@ export declare namespace ChatFullInfo {
     pinned_message?: Message;
     /** Default chat member permissions, for groups and supergroups */
     permissions?: ChatPermissions;
-    /** True, if gifts can be sent to the chat */
-    can_send_gift?: true;
+    /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
+    accepted_gift_types: AcceptedGiftTypes;
     /** True, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats. */
     can_send_paid_media?: undefined;
     /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds */
@@ -499,8 +499,8 @@ export declare namespace ChatFullInfo {
     pinned_message?: Message;
     /** Default chat member permissions, for groups and supergroups */
     permissions?: undefined;
-    /** True, if gifts can be sent to the chat */
-    can_send_gift?: true;
+    /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
+    accepted_gift_types: AcceptedGiftTypes;
     /** True, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats. */
     can_send_paid_media?: true;
     /** For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds */


### PR DESCRIPTION
As mentioned in https://core.telegram.org/bots/api#april-11-2025, the field `accepted_gift_types` has replaced `can_send_gift` in all chat types including groups and channel.