### PR TITLE
docs: wrap strings unintentionally interpreted as JSDoc in backticks

### DIFF
--- a/inline.ts
+++ b/inline.ts
@@ -679,7 +679,7 @@ export interface InputInvoiceMessageContent {
   description: string;
   /** Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use it for your internal processes. */
   payload: string;
-  /** Payment provider token, obtained via @BotFather. Pass an empty string for payments in Telegram Stars. */
+  /** Payment provider token, obtained via `@BotFather`. Pass an empty string for payments in Telegram Stars. */
   provider_token?: string;
   /** Three-letter ISO 4217 currency code, see more on currencies. Pass “XTR” for payments in Telegram Stars. */
   currency: string;
@@ -717,7 +717,7 @@ export interface InputInvoiceMessageContent {
 
 /** Represents a result of an inline query that was chosen by the user and sent to their chat partner.
 
-Note: It is necessary to enable inline feedback via @BotFather in order to receive these objects in updates. */
+Note: It is necessary to enable inline feedback via `@BotFather` in order to receive these objects in updates. */
 export interface ChosenInlineResult {
   /** The unique identifier for the result that was chosen */
   result_id: string;

--- a/markup.ts
+++ b/markup.ts
@@ -139,7 +139,7 @@ export interface ReplyKeyboardMarkup {
   one_time_keyboard?: boolean;
   /** The placeholder to be shown in the input field when the keyboard is active; 1-64 characters */
   input_field_placeholder?: string;
-  /** Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message.
+  /** Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are `@mentioned` in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message.
 
   Example: A user requests to change the bot's language, bot replies to the request with a keyboard to select the new language. Other users in the group don't see the keyboard. */
   selective?: boolean;
@@ -197,7 +197,7 @@ export interface KeyboardButtonPollType {
 export interface ReplyKeyboardRemove {
   /** Requests clients to remove the custom keyboard (user will not be able to summon this keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in ReplyKeyboardMarkup) */
   remove_keyboard: true;
-  /** Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message.
+  /** Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are `@mentioned` in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message.
 
   Example: A user votes in a poll, bot returns confirmation message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options to users who haven't voted yet. */
   selective?: boolean;
@@ -217,7 +217,7 @@ export interface ForceReply {
   force_reply: true;
   /** The placeholder to be shown in the input field when the reply is active; 1-64 characters */
   input_field_placeholder?: string;
-  /** Use this parameter if you want to force reply from specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message. */
+  /** Use this parameter if you want to force reply from specific users only. Targets: 1) users that are `@mentioned` in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message. */
   selective?: boolean;
 }
 

--- a/message.ts
+++ b/message.ts
@@ -552,7 +552,7 @@ export type ParseMode = "Markdown" | "MarkdownV2" | "HTML";
 
 export declare namespace MessageEntity {
   interface AbstractMessageEntity {
-    /** Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag or #hashtag@chatusername), “cashtag” ($USD or $USD@chatusername), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers) */
+    /** Type of the entity. Currently, can be “mention” (`@username`), “hashtag” (#hashtag or `#hashtag@chatusername`), “cashtag” ($USD or `$USD@chatusername`), “bot_command” (`/start@jobs_bot`), “url” (https://telegram.org), “email” (`do-not-reply@telegram.org`), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers) */
     type: string;
     /** Offset in UTF-16 code units to the start of the entity */
     offset: number;
@@ -677,7 +677,7 @@ export interface ExternalReplyInfo {
 export interface ReplyParameters {
   /** Identifier of the message that will be replied to in the current chat, or in the chat chat_id if it is specified */
   message_id: number;
-  /** If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername). Not supported for messages sent on behalf of a business account and messages from channel direct messages chats. */
+  /** If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format `@channelusername`). Not supported for messages sent on behalf of a business account and messages from channel direct messages chats. */
   chat_id?: number | string;
   /** Identifier of the specific checklist task to be replied to */
   checklist_task_id?: number;

--- a/methods.ts
+++ b/methods.ts
@@ -144,7 +144,7 @@ export type ApiMethods<F> = {
   sendMessage(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -182,13 +182,13 @@ export type ApiMethods<F> = {
 
   /** Use this method to forward messages of any kind. Service messages and messages with protected content can't be forwarded. On success, the sent Message is returned. */
   forwardMessage(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be forwarded; required if the message is forwarded to a direct messages chat */
     direct_messages_topic_id?: number;
-    /** Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername) */
+    /** Unique identifier for the chat where the original message was sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** New start timestamp for the copied video in the message */
     video_start_timestamp?: number;
@@ -204,13 +204,13 @@ export type ApiMethods<F> = {
 
   /** Use this method to forward multiple messages of any kind. If some of the specified messages can't be found or forwarded, they are skipped. Service messages and messages with protected content can't be forwarded. Album grouping is kept for forwarded messages. On success, an array of MessageId of the sent messages is returned. */
   forwardMessages(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the messages will be forwarded; required if the messages are forwarded to a direct messages chat */
     direct_messages_topic_id?: number;
-    /** Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername) */
+    /** Unique identifier for the chat where the original messages were sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** A list of 1-100 identifiers of messages in the chat from_chat_id to forward. The identifiers must be specified in a strictly increasing order. */
     message_ids: number[];
@@ -222,13 +222,13 @@ export type ApiMethods<F> = {
 
   /** Use this method to copy messages of any kind. Service messages, paid media messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied. A quiz poll can be copied only if the value of the field correct_option_id is known to the bot. The method is analogous to the method forwardMessage, but the copied message doesn't have a link to the original message. Returns the MessageId of the sent message on success. */
   copyMessage(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
-    /** Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername) */
+    /** Unique identifier for the chat where the original message was sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** Message identifier in the chat specified in from_chat_id */
     message_id: number;
@@ -264,13 +264,13 @@ export type ApiMethods<F> = {
 
   /** Use this method to copy messages of any kind. If some of the specified messages can't be found or copied, they are skipped. Service messages, paid media messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied. A quiz poll can be copied only if the value of the field correct_option_id is known to the bot. The method is analogous to the method forwardMessages, but the copied messages don't have a link to the original message. Album grouping is kept for copied messages. On success, an array of MessageId of the sent messages is returned. */
   copyMessages(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the messages will be sent; required if the messages are sent to a direct messages chat */
     direct_messages_topic_id?: number;
-    /** Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername) */
+    /** Unique identifier for the chat where the original messages were sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** A list of 1-100 identifiers of messages in the chat from_chat_id to copy. The identifiers must be specified in a strictly increasing order. */
     message_ids: number[];
@@ -286,7 +286,7 @@ export type ApiMethods<F> = {
   sendPhoto(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -332,7 +332,7 @@ export type ApiMethods<F> = {
   sendAudio(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -380,7 +380,7 @@ export type ApiMethods<F> = {
   sendDocument(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -424,7 +424,7 @@ export type ApiMethods<F> = {
   sendVideo(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -482,7 +482,7 @@ export type ApiMethods<F> = {
   sendAnimation(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -534,7 +534,7 @@ export type ApiMethods<F> = {
   sendVoice(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -577,7 +577,7 @@ export type ApiMethods<F> = {
   sendVideoNote(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -617,7 +617,7 @@ export type ApiMethods<F> = {
   sendMediaGroup(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -653,7 +653,7 @@ export type ApiMethods<F> = {
   sendLocation(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -697,7 +697,7 @@ export type ApiMethods<F> = {
   editMessageLiveLocation(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id?: number | string;
     /** Required if inline_message_id is not specified. Identifier of the message to edit */
     message_id?: number;
@@ -723,7 +723,7 @@ export type ApiMethods<F> = {
   stopMessageLiveLocation(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id?: number | string;
     /** Required if inline_message_id is not specified. Identifier of the message with live location to stop */
     message_id?: number;
@@ -737,7 +737,7 @@ export type ApiMethods<F> = {
   sendPaidMedia(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername). If the chat is a channel, all Telegram Star proceeds from this media will be credited to the chat's balance. Otherwise, they will be credited to the bot's balance. */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). If the chat is a channel, all Telegram Star proceeds from this media will be credited to the chat's balance. Otherwise, they will be credited to the bot's balance. */
     chat_id: number | string;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -777,7 +777,7 @@ export type ApiMethods<F> = {
   sendVenue(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -825,7 +825,7 @@ export type ApiMethods<F> = {
   sendContact(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -865,7 +865,7 @@ export type ApiMethods<F> = {
   sendPoll(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername). Polls can't be sent to channel direct messages chats. */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). Polls can't be sent to channel direct messages chats. */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -955,7 +955,7 @@ export type ApiMethods<F> = {
   sendDice(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -1000,7 +1000,7 @@ export type ApiMethods<F> = {
   sendChatAction(args: {
     /** Unique identifier of the business connection on behalf of which the action will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername). Channel chats and channel direct messages chats aren't supported. */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel chats and channel direct messages chats aren't supported. */
     chat_id: number | string;
     /** Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes. */
     action:
@@ -1021,7 +1021,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to change the chosen reactions on a message. Service messages of some types can't be reacted to. Automatically forwarded messages from a channel to its discussion group have the same available reactions as messages in the channel. Bots can't use paid reactions. Returns True on success. */
   setMessageReaction(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Identifier of the target message */
     message_id: number;
@@ -1065,7 +1065,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to ban a user in a group, a supergroup or a channel. In the case of supergroups and channels, the user will not be able to return to the chat on their own using invite links, etc., unless unbanned first. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success. */
   banChatMember(args: {
-    /** Unique identifier for the target group or username of the target supergroup or channel (in the format @channelusername) */
+    /** Unique identifier for the target group or username of the target supergroup or channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1077,7 +1077,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to unban a previously banned user in a supergroup or channel. The user will not return to the group or channel automatically, but will be able to join via link, etc. The bot must be an administrator for this to work. By default, this method guarantees that after the call the user is not a member of the chat, but will be able to join it. So if the user is a member of the chat they will also be removed from the chat. If you don't want this, use the parameter only_if_banned. Returns True on success. */
   unbanChatMember(args: {
-    /** Unique identifier for the target group or username of the target supergroup or channel (in the format @channelusername) */
+    /** Unique identifier for the target group or username of the target supergroup or channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1087,7 +1087,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate administrator rights. Pass True for all permissions to lift restrictions from a user. Returns True on success. */
   restrictChatMember(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1101,7 +1101,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Pass False for all boolean parameters to demote a user. Returns True on success. */
   promoteChatMember(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1141,7 +1141,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to set a custom title for an administrator in a supergroup promoted by the bot. Returns True on success. */
   setChatAdministratorCustomTitle(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1151,7 +1151,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat won't be able to send messages on behalf of any of their channels. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success. */
   banChatSenderChat(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target sender chat */
     sender_chat_id: number;
@@ -1159,7 +1159,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to unban a previously banned channel chat in a supergroup or channel. The bot must be an administrator for this to work and must have the appropriate administrator rights. Returns True on success. */
   unbanChatSenderChat(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target sender chat */
     sender_chat_id: number;
@@ -1167,7 +1167,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a supergroup for this to work and must have the can_restrict_members administrator rights. Returns True on success. */
   setChatPermissions(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** An object for new default chat permissions */
     permissions: ChatPermissions;
@@ -1179,13 +1179,13 @@ export type ApiMethods<F> = {
 
   Note: Each administrator in a chat generates their own invite links. Bots can't use invite links generated by other administrators. If you want your bot to work with invite links, it will need to generate its own link using exportChatInviteLink or by calling the getChat method. If your bot needs to generate a new primary invite link replacing its previous one, use exportChatInviteLink again. */
   exportChatInviteLink(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
   }): string;
 
   /** Use this method to create an additional invite link for a chat. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. The link can be revoked using the method revokeChatInviteLink. Returns the new invite link as ChatInviteLink object. */
   createChatInviteLink(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Invite link name; 0-32 characters */
     name?: string;
@@ -1199,7 +1199,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to edit a non-primary invite link created by the bot. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns the edited invite link as a ChatInviteLink object. */
   editChatInviteLink(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** The invite link to edit */
     invite_link: string;
@@ -1215,7 +1215,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to create a subscription invite link for a channel chat. The bot must have the can_invite_users administrator rights. The link can be edited using the method editChatSubscriptionInviteLink or revoked using the method revokeChatInviteLink. Returns the new invite link as a ChatInviteLink object. */
   createChatSubscriptionInviteLink(args: {
-    /** Unique identifier for the target channel chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target channel chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Invite link name; 0-32 characters */
     name?: string;
@@ -1227,7 +1227,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to edit a subscription invite link created by the bot. The bot must have the can_invite_users administrator rights. Returns the edited invite link as a ChatInviteLink object. */
   editChatSubscriptionInviteLink(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** The invite link to edit */
     invite_link: string;
@@ -1237,7 +1237,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to revoke an invite link created by the bot. If the primary link is revoked, a new link is automatically generated. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns the revoked invite link as ChatInviteLink object. */
   revokeChatInviteLink(args: {
-    /** Unique identifier of the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier of the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** The invite link to revoke */
     invite_link: string;
@@ -1245,7 +1245,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to approve a chat join request. The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right. Returns True on success. */
   approveChatJoinRequest(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1253,7 +1253,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to decline a chat join request. The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right. Returns True on success. */
   declineChatJoinRequest(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1281,7 +1281,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success. */
   setChatPhoto(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** New chat photo, uploaded using multipart/form-data */
     photo: F;
@@ -1289,13 +1289,13 @@ export type ApiMethods<F> = {
 
   /** Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success. */
   deleteChatPhoto(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success. */
   setChatTitle(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** New chat title, 1-128 characters */
     title: string;
@@ -1303,7 +1303,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to change the description of a group, a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success. */
   setChatDescription(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** New chat description, 0-255 characters */
     description?: string;
@@ -1313,7 +1313,7 @@ export type ApiMethods<F> = {
   pinChatMessage(args: {
     /** Unique identifier of the business connection on behalf of which the message will be pinned */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Identifier of a message to pin */
     message_id: number;
@@ -1325,7 +1325,7 @@ export type ApiMethods<F> = {
   unpinChatMessage(args: {
     /** Unique identifier of the business connection on behalf of which the message will be unpinned */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Identifier of the message to unpin. Required if business_connection_id is specified. If not specified, the most recent pinned message (by sending date) will be unpinned. */
     message_id?: number;
@@ -1333,25 +1333,25 @@ export type ApiMethods<F> = {
 
   /** Use this method to clear the list of pinned messages in a chat. In private chats and channel direct messages chats, no additional rights are required to unpin all pinned messages. Conversely, the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right to unpin all pinned messages in groups and channels respectively. Returns True on success. */
   unpinAllChatMessages(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method for your bot to leave a group, supergroup or channel. Returns True on success. */
   leaveChat(args: {
-    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername). Channel direct messages chats aren't supported; leave the corresponding channel instead. */
+    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format `@channelusername`). Channel direct messages chats aren't supported; leave the corresponding channel instead. */
     chat_id: number | string;
   }): true;
 
   /** Use this method to get up-to-date information about the chat. Returns a ChatFullInfo object on success. */
   getChat(args: {
-    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format `@channelusername`) */
     chat_id: number | string;
   }): ChatFullInfo;
 
   /** Use this method to get a list of administrators in a chat, which aren't bots. Returns an Array of ChatMember objects. */
   getChatAdministrators(args: {
-    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format `@channelusername`) */
     chat_id: number | string;
   }): Array<ChatMemberOwner | ChatMemberAdministrator>;
 
@@ -1361,13 +1361,13 @@ export type ApiMethods<F> = {
 
   /** Use this method to get the number of members in a chat. Returns Int on success. */
   getChatMemberCount(args: {
-    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format `@channelusername`) */
     chat_id: number | string;
   }): number;
 
   /** Use this method to get information about a member of a chat. The method is only guaranteed to work for other users if the bot is an administrator in the chat. Returns a ChatMember object on success. */
   getChatMember(args: {
-    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1375,7 +1375,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to set a new group sticker set for a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set ly returned in getChat requests to check if the bot can use this method. Returns True on success. */
   setChatStickerSet(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Name of the sticker set to be set as the group sticker set */
     sticker_set_name: string;
@@ -1383,7 +1383,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to delete a group sticker set from a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set ly returned in getChat requests to check if the bot can use this method. Returns True on success. */
   deleteChatStickerSet(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
@@ -1391,7 +1391,7 @@ export type ApiMethods<F> = {
   getForumTopicIconStickers(): Sticker[];
   /** Use this method to create a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns information about the created topic as a ForumTopic object. */
   createForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Topic name, 1-128 characters */
     name: string;
@@ -1409,7 +1409,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
   editForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1421,7 +1421,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to close an open topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
   closeForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1429,7 +1429,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to reopen a closed topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
   reopenForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1437,7 +1437,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to delete a forum topic along with all its messages in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_delete_messages administrator rights. Returns True on success. */
   deleteForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1445,7 +1445,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success. */
   unpinAllForumTopicMessages(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1453,7 +1453,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to edit the name of the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success. */
   editGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** New topic name, 1-128 characters */
     name: string;
@@ -1461,37 +1461,37 @@ export type ApiMethods<F> = {
 
   /** Use this method to close an open 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success. */
   closeGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to reopen a closed 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically unhidden if it was hidden. Returns True on success. */
   reopenGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to hide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically closed if it was open. Returns True on success. */
   hideGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to unhide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success. */
   unhideGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to clear the list of pinned messages in a General forum topic. The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success. */
   unpinAllGeneralForumTopicMessages(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the user as a notification at the top of the chat screen or as an alert. On success, True is returned.
 
-  Alternatively, the user can be redirected to the specified Game URL. For this option to work, you must first create a game for your bot via @BotFather and accept the terms. Otherwise, you may use links like t.me/your_bot?start=XXXX that open your bot with a parameter. */
+  Alternatively, the user can be redirected to the specified Game URL. For this option to work, you must first create a game for your bot via `@BotFather` and accept the terms. Otherwise, you may use links like t.me/your_bot?start=XXXX that open your bot with a parameter. */
   answerCallbackQuery(args: {
     /** Unique identifier for the query to be answered */
     callback_query_id: string;
@@ -1499,7 +1499,7 @@ export type ApiMethods<F> = {
     text?: string;
     /** If True, an alert will be shown by the client instead of a notification at the top of the chat screen. Defaults to false. */
     show_alert?: boolean;
-    /** URL that will be opened by the user's client. If you have created a Game and accepted the conditions via @BotFather, specify the URL that opens your game - note that this will only work if the query comes from a callback_game button.
+    /** URL that will be opened by the user's client. If you have created a Game and accepted the conditions via `@BotFather`, specify the URL that opens your game - note that this will only work if the query comes from a callback_game button.
 
     Otherwise, you may use links like t.me/your_bot?start=XXXX that open your bot with a parameter. */
     url?: string;
@@ -1509,7 +1509,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object. */
   getUserChatBoosts(args: {
-    /** Unique identifier for the chat or username of the channel (in the format @channelusername) */
+    /** Unique identifier for the chat or username of the channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -1624,7 +1624,7 @@ export type ApiMethods<F> = {
   editMessageText(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id?: number | string;
     /** Required if inline_message_id is not specified. Identifier of the message to edit */
     message_id?: number;
@@ -1646,7 +1646,7 @@ export type ApiMethods<F> = {
   editMessageCaption(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id?: number | string;
     /** Required if inline_message_id is not specified. Identifier of the message to edit */
     message_id?: number;
@@ -1668,7 +1668,7 @@ export type ApiMethods<F> = {
   editMessageMedia(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id?: number | string;
     /** Required if inline_message_id is not specified. Identifier of the message to edit */
     message_id?: number;
@@ -1684,7 +1684,7 @@ export type ApiMethods<F> = {
   editMessageReplyMarkup(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id?: number | string;
     /** Required if inline_message_id is not specified. Identifier of the message to edit */
     message_id?: number;
@@ -1698,7 +1698,7 @@ export type ApiMethods<F> = {
   stopPoll(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Identifier of the original message with the poll */
     message_id: number;
@@ -1718,7 +1718,7 @@ export type ApiMethods<F> = {
   - If the bot has can_manage_direct_messages administrator right in a channel, it can delete any message in the corresponding direct messages chat.
   Returns True on success. */
   deleteMessage(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Identifier of the message to delete */
     message_id: number;
@@ -1726,7 +1726,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to delete multiple messages simultaneously. Returns True on success. */
   deleteMessages(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** A list of 1-100 identifiers of messages to delete. See deleteMessage for limitations on which messages can be deleted */
     message_ids: number[];
@@ -1914,7 +1914,7 @@ export type ApiMethods<F> = {
   sendSticker(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -2085,7 +2085,7 @@ export type ApiMethods<F> = {
   sendGift(args: {
     /** Required if chat_id is not specified. Unique identifier of the target user who will receive the gift. */
     user_id?: number;
-    /** Required if user_id is not specified. Unique identifier for the chat or username of the channel (in the format @channelusername) that will receive the gift. */
+    /** Required if user_id is not specified. Unique identifier for the chat or username of the channel (in the format `@channelusername`) that will receive the gift. */
     chat_id?: number | string;
     /** Identifier of the gift */
     gift_id: string;
@@ -2160,7 +2160,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to send invoices. On success, the sent Message is returned. */
   sendInvoice(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -2236,7 +2236,7 @@ export type ApiMethods<F> = {
     description: string;
     /** Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use it for your internal processes. */
     payload: string;
-    /** Payment provider token, obtained via @BotFather. Pass an empty string for payments in Telegram Stars. */
+    /** Payment provider token, obtained via `@BotFather`. Pass an empty string for payments in Telegram Stars. */
     provider_token?: string;
     /** Three-letter ISO 4217 currency code, see more on currencies */
     currency: string;
@@ -2332,7 +2332,7 @@ export type ApiMethods<F> = {
 
   /** Verifies a chat on behalf of the organization which is represented by the bot. Returns True on success. */
   verifyChat(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername). Channel direct messages chats can't be verified. */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). Channel direct messages chats can't be verified. */
     chat_id: number | string;
     /** Custom description for the verification; 0-70 characters. Must be empty if the organization isn't allowed to provide a custom verification description. */
     custom_description?: string;
@@ -2346,7 +2346,7 @@ export type ApiMethods<F> = {
 
   /** Removes verification from a chat that is currently verified on behalf of the organization represented by the bot. Returns True on success. */
   removeChatVerification(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
   }): true;
 

--- a/settings.ts
+++ b/settings.ts
@@ -122,7 +122,7 @@ export interface BotCommandScopeAllChatAdministrators {
 export interface BotCommandScopeChat {
   /** Scope type, must be chat */
   type: "chat";
-  /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername). Channel direct messages chats and channel chats aren't supported. */
+  /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel direct messages chats and channel chats aren't supported. */
   chat_id: number | string;
 }
 
@@ -130,7 +130,7 @@ export interface BotCommandScopeChat {
 export interface BotCommandScopeChatAdministrators {
   /** Scope type, must be chat_administrators */
   type: "chat_administrators";
-  /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername). Channel direct messages chats and channel chats aren't supported. */
+  /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel direct messages chats and channel chats aren't supported. */
   chat_id: number | string;
 }
 
@@ -138,7 +138,7 @@ export interface BotCommandScopeChatAdministrators {
 export interface BotCommandScopeChatMember {
   /** Scope type, must be chat_member */
   type: "chat_member";
-  /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername). Channel direct messages chats and channel chats aren't supported. */
+  /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel direct messages chats and channel chats aren't supported. */
   chat_id: number | string;
   /** Unique identifier of the target user */
   user_id: number;


### PR DESCRIPTION
Mirroring changes in https://github.com/grammyjs/grammY/pull/833 while v2 is not yet published. I kept it as simple as possible, as the types will be replaced entirely with v2.

Really minor change, a few strings are interpreted as JSDoc currently, for example see how the code below is rendered on vscode:
```ts
    /**
     * Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are @mentioned in the _text_ of the {@link Message | Message} object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message.
     *
     * _Example:_ A user votes in a poll, bot returns confirmation message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options to users who haven't voted yet.
     */
    selective?: boolean;
```
<img width="1171" height="141" alt="image" src="https://github.com/user-attachments/assets/b291d800-3951-4537-ab94-03b56a80cf83" />

